### PR TITLE
Remove students banner from front page

### DIFF
--- a/_events/students_start_of_term.md
+++ b/_events/students_start_of_term.md
@@ -1,6 +1,6 @@
 ---
 name: Students Start of Year
-status: live
+status: old
 overlayCaption: Hello Students!
 backgroundColour: rgb(96, 12, 12);
 textColour: rgb(237, 206, 30);


### PR DESCRIPTION
It's now past the start of term. We will replace this with something
Christmassy soon.